### PR TITLE
llmModule 26.07.0: catch case if no model for remote api

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: llmModule
 Type: Package
 Title: R Interface for Large Language Model APIs
-Version: 26.06.1
-Date: 2026-06-05
+Version: 26.07.0
+Date: 2026-07-01
 Authors@R: c(
             person("Ricardo", "Fernandes", email = "ldv1452@gmail.com", role = c("aut", "cre")),
             person("Antonia", "Runge", email = "antonia.runge@inwt-statistics.de", role = c("aut"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# llmModule 26.07.0
+
+## Bug Fixes
+- Fixed `ask_llm()` returning HTTP 400 for `RemoteLlmApi` providers (e.g. `DeepSeek`) when no `model` argument was supplied; `send_prompt.RemoteLlmApi()` now returns a clear error instead of forwarding a `NULL` model to the API.
+
 # llmModule 26.06.1
 
 ## New Features

--- a/R/01-RemoteLlmApi-class.R
+++ b/R/01-RemoteLlmApi-class.R
@@ -220,13 +220,15 @@ send_prompt.RemoteLlmApi <- function(api, prompt_config) {
   # Filter the prompt configuration
   prompt_config <- llm_filter_config(api, prompt_config)
 
-  if (is.null(prompt_config$model) || identical(prompt_config$model, "")) {
-    result <- list()
-    attr(result, "error") <- sprintf(
-      "No model specified for provider '%s'. Provide a model via the 'model' argument.",
-      api$provider
-    )
-    return(result)
+  model <- prompt_config$model
+  if (!is.character(model) || length(model) != 1 || is.na(model) || !nzchar(trimws(model))) {
+    return(structure(
+      list(),
+      error = sprintf(
+        "No model specified for provider '%s'. Provide a model via the 'model' argument.",
+        api$provider
+      )
+    ))
   }
 
   connectivity_error <- check_remote_connectivity(api$no_internet)

--- a/R/01-RemoteLlmApi-class.R
+++ b/R/01-RemoteLlmApi-class.R
@@ -220,6 +220,15 @@ send_prompt.RemoteLlmApi <- function(api, prompt_config) {
   # Filter the prompt configuration
   prompt_config <- llm_filter_config(api, prompt_config)
 
+  if (is.null(prompt_config$model) || identical(prompt_config$model, "")) {
+    result <- list()
+    attr(result, "error") <- sprintf(
+      "No model specified for provider '%s'. Provide a model via the 'model' argument.",
+      api$provider
+    )
+    return(result)
+  }
+
   connectivity_error <- check_remote_connectivity(api$no_internet)
   if (!is.null(connectivity_error)) {
     result <- list()


### PR DESCRIPTION
# llmModule 26.07.0

## Bug Fixes
- Fixed `ask_llm()` returning HTTP 400 for `RemoteLlmApi` providers (e.g. `DeepSeek`) when no `model` argument was supplied; `send_prompt.RemoteLlmApi()` now returns a clear error instead of forwarding a `NULL` model to the API.